### PR TITLE
name of parameter has to match

### DIFF
--- a/Routes/index.js
+++ b/Routes/index.js
@@ -80,7 +80,7 @@ router.get("/users", (req, res, next) => {
  *      tags: [Users]
  *      parameters:
  *        - in: path
- *          name: userId
+ *          name: id
  *          schema:
  *            type: string
  *          required: true


### PR DESCRIPTION
/users/{id} won't work. 
because "name: userId" has be "name: id"